### PR TITLE
MainActivity: add Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS to activi…

### DIFF
--- a/app/src/main/java/se/blunden/xbmclauncher/MainActivity.java
+++ b/app/src/main/java/se/blunden/xbmclauncher/MainActivity.java
@@ -31,6 +31,7 @@ public class MainActivity extends Activity {
          * stack as needed for the system to broadcast BOOT_COMPLETED.
          */
         activityIntent.addCategory(Intent.CATEGORY_HOME);
+        activityIntent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
 		
 		try {
 			//check if connected!


### PR DESCRIPTION
…ty call

* Android likes to kill apps that have been sitting idle for a long time
  under various criteria. This is especially apparent on my Chromecast
  with GoogleTV after it's been sitting idle for 6 hours, activity manager
  likes to destroy Kodi:

  ActivityTaskManager: Trimming out-of-range visible task=TaskRecord{bca911b #2530 A=org.xbmc.kodi U=0 StackId=579 sz=1}
  (see line 1076 from the link at the bottom of this commit message)

* Normally this wouldn't be the most annoying thing ever. When I turn the TV
  on, Kodi gets nuked by AM, then the launcher app fires it back up. Sure you
  have to wait a few seconds for the splash screen, but I also use PVR and
  that takes considerably longer to start up/scan channels in, during which
  the device is very janky and will often freeze when you try to run even a
  local video.

* Digging through the various reasons we could avoid the trimming of the app in
  trimInactiveRecentTasks() led me to notice if you prevent the app from being
  a recent app (line 1173) AM will leave it alone (assuming it's the top app in
  the stack, which it is).

* https://android.googlesource.com/platform/frameworks/base/+/refs/heads/pie-release/services/core/java/com/android/server/am/RecentTasks.java